### PR TITLE
fix: incorrect offset on archives that have extra data

### DIFF
--- a/PakCacher.cs
+++ b/PakCacher.cs
@@ -88,9 +88,10 @@ namespace pakcacher
                                     zipFileInfo.filename = reader.ReadChars(zipFileInfo.filenamelen);
 
                                     // to data offset
-                                    zipFileInfo.offset += 30 + zipFileInfo.filenamelen;
+                                    zipFileInfo.offset += 30 + zipFileInfo.filenamelen + zipFileInfo.extrafieldlen;
 
-                                    //skip file data
+                                    // skip extra/file data
+                                    reader.ReadBytes(zipFileInfo.extrafieldlen);
                                     reader.ReadBytes(zipFileInfo.compressed);
 
                                     if (isPak) CreateCache(zipFileInfo, writestream);


### PR DESCRIPTION
Hello, first of all thanks for your work with this! Very useful tool.

I have noticed that with certain archiving tools this does not generate the cache file correctly if the archive contains extra data, you need to specifically exclude it with a command like `zip -rX default_other.pak *` or use something like `7z` which omits it by default.

Made a small change which adjusts the offset and advances the read if this data is present. 

I have tested this does not break the behaviour of paks and caches if this data is present in the archive.

I have not tested if this affects the issue mentioned in the readme with certain cache files.